### PR TITLE
Enable usage of fine grained tokens for Github

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,8 +17,8 @@ fi
 GITHUB_AUTH_TOKEN="$(cat "${ENV_DIR}/GITHUB_AUTH_TOKEN")"
 
 # Set the credentials in `.netrc` for build time only (they are intentionally not put in the slug).
-echo "machine github.com login ${GITHUB_AUTH_TOKEN} password x-oauth-basic" >> "${HOME}/.netrc"
-echo "machine api.github.com login ${GITHUB_AUTH_TOKEN} password x-oauth-basic" >> "${HOME}/.netrc"
+echo "machine github.com login oauth2 password ${GITHUB_AUTH_TOKEN}" >> "${HOME}/.netrc"
+echo "machine api.github.com login oauth2 password ${GITHUB_AUTH_TOKEN}" >> "${HOME}/.netrc"
 
 # Configure `curl` to use `.netrc` (again at build time only).
 echo '--netrc-optional' >> "${HOME}/.curlrc"


### PR DESCRIPTION
Github's fine grained tokens no longer allow the `[AUTH_TOKEN]:x-oauth-basic` login format. Instead, they follow `oauth2:[AUTH_TOKEN]`.

This PR modifies the netrc entries to conform to the latter format.